### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.5
+
+* Prepare for 1.0.0 version of sensors and package_info. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 ## [0.7.4] - SingleInput Dialog Breaking Changes
 
 * Breaking changes to single input dialog

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: commons
 description: Commons Flutter package includes alert dialogs, extension functions and much more... Written by 'Ch Arbaz Mateen'
-version: 0.7.4
+version: 0.7.5
 homepage: https://www.arbazmateen.com
 repository: https://github.com/Arbaz-Softagics/commons
 
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  package_info: ^0.4.0+13
+  package_info: '>=0.4.0+13 <2.0.0'
   device_info: ^0.4.1+4
   get_version: ^0.2.0+1
   url_launcher: ^5.4.1


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).